### PR TITLE
[bug]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,117 +1,92 @@
 # Changelog for angular
 
-## [Unreleased](https://github.com/modbus2mqtt/angular/tree/HEAD)
+## [v0.12.19](https://github.com/volkmarnissen/angular/tree/v0.12.19) (2025-01-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.20...HEAD)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.18...v0.12.19)
 
-**Merged pull requests:**
+## [v0.12.18](https://github.com/volkmarnissen/angular/tree/v0.12.18) (2025-01-15)
 
-- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#8](https://github.com/modbus2mqtt/angular/pull/8) ([volkmarnissen](https://github.com/volkmarnissen))
-- Angular TcpBridge Fix [\#7](https://github.com/modbus2mqtt/angular/pull/7) ([volkmarnissen](https://github.com/volkmarnissen))
-- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#6](https://github.com/modbus2mqtt/angular/pull/6) ([volkmarnissen](https://github.com/volkmarnissen))
-- Modbus Error Handling and Monitoring [\#5](https://github.com/modbus2mqtt/angular/pull/5) ([volkmarnissen](https://github.com/volkmarnissen))
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.17...v0.12.18)
 
-## [v0.12.20](https://github.com/modbus2mqtt/angular/tree/v0.12.20) (2025-04-14)
+## [v0.12.17](https://github.com/volkmarnissen/angular/tree/v0.12.17) (2025-01-02)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.19...v0.12.20)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.16...v0.12.17)
 
-**Merged pull requests:**
+## [v0.12.16](https://github.com/volkmarnissen/angular/tree/v0.12.16) (2024-12-31)
 
-- Please update me [\#4](https://github.com/modbus2mqtt/angular/pull/4) ([volkmarnissen](https://github.com/volkmarnissen))
-- Fixed package-lock.json [\#3](https://github.com/modbus2mqtt/angular/pull/3) ([volkmarnissen](https://github.com/volkmarnissen))
-- Adding support for discrete inputs [\#2](https://github.com/modbus2mqtt/angular/pull/2) ([arturmietek](https://github.com/arturmietek))
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.15...v0.12.16)
 
-## [v0.12.19](https://github.com/modbus2mqtt/angular/tree/v0.12.19) (2025-01-16)
+## [v0.12.15](https://github.com/volkmarnissen/angular/tree/v0.12.15) (2024-12-30)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.18...v0.12.19)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.14...v0.12.15)
 
-## [v0.12.18](https://github.com/modbus2mqtt/angular/tree/v0.12.18) (2025-01-15)
+## [v0.12.14](https://github.com/volkmarnissen/angular/tree/v0.12.14) (2024-12-30)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.17...v0.12.18)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/0.12.14...v0.12.14)
 
-## [v0.12.17](https://github.com/modbus2mqtt/angular/tree/v0.12.17) (2025-01-02)
+## [0.12.14](https://github.com/volkmarnissen/angular/tree/0.12.14) (2024-12-13)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.16...v0.12.17)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.13...0.12.14)
 
-**Merged pull requests:**
+## [v0.12.13](https://github.com/volkmarnissen/angular/tree/v0.12.13) (2024-12-13)
 
-- Adding signed int 32 and unsigned int 32 options to number format [\#1](https://github.com/modbus2mqtt/angular/pull/1) ([arturmietek](https://github.com/arturmietek))
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.12...v0.12.13)
 
-## [v0.12.16](https://github.com/modbus2mqtt/angular/tree/v0.12.16) (2024-12-31)
+## [v0.12.12](https://github.com/volkmarnissen/angular/tree/v0.12.12) (2024-12-11)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.15...v0.12.16)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.11...v0.12.12)
 
-## [v0.12.15](https://github.com/modbus2mqtt/angular/tree/v0.12.15) (2024-12-30)
+## [v0.12.11](https://github.com/volkmarnissen/angular/tree/v0.12.11) (2024-11-22)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.14...v0.12.15)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.10...v0.12.11)
 
-## [v0.12.14](https://github.com/modbus2mqtt/angular/tree/v0.12.14) (2024-12-30)
+## [v0.12.10](https://github.com/volkmarnissen/angular/tree/v0.12.10) (2024-11-19)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/0.12.14...v0.12.14)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.9...v0.12.10)
 
-## [0.12.14](https://github.com/modbus2mqtt/angular/tree/0.12.14) (2024-12-13)
+## [v0.12.9](https://github.com/volkmarnissen/angular/tree/v0.12.9) (2024-11-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.13...0.12.14)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.8...v0.12.9)
 
-## [v0.12.13](https://github.com/modbus2mqtt/angular/tree/v0.12.13) (2024-12-13)
+## [v0.12.8](https://github.com/volkmarnissen/angular/tree/v0.12.8) (2024-11-14)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.12...v0.12.13)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.7...v0.12.8)
 
-## [v0.12.12](https://github.com/modbus2mqtt/angular/tree/v0.12.12) (2024-12-11)
+## [v0.12.7](https://github.com/volkmarnissen/angular/tree/v0.12.7) (2024-10-23)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.11...v0.12.12)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.6...v0.12.7)
 
-## [v0.12.11](https://github.com/modbus2mqtt/angular/tree/v0.12.11) (2024-11-22)
+## [v0.12.6](https://github.com/volkmarnissen/angular/tree/v0.12.6) (2024-10-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.10...v0.12.11)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.5...v0.12.6)
 
-## [v0.12.10](https://github.com/modbus2mqtt/angular/tree/v0.12.10) (2024-11-19)
+## [v0.12.5](https://github.com/volkmarnissen/angular/tree/v0.12.5) (2024-09-24)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.9...v0.12.10)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.4...v0.12.5)
 
-## [v0.12.9](https://github.com/modbus2mqtt/angular/tree/v0.12.9) (2024-11-16)
+## [v0.12.4](https://github.com/volkmarnissen/angular/tree/v0.12.4) (2024-09-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.8...v0.12.9)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.3...v0.12.4)
 
-## [v0.12.8](https://github.com/modbus2mqtt/angular/tree/v0.12.8) (2024-11-14)
+## [v0.12.3](https://github.com/volkmarnissen/angular/tree/v0.12.3) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.7...v0.12.8)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.2...v0.12.3)
 
-## [v0.12.7](https://github.com/modbus2mqtt/angular/tree/v0.12.7) (2024-10-23)
+## [v0.12.2](https://github.com/volkmarnissen/angular/tree/v0.12.2) (2024-08-27)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.6...v0.12.7)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.0...v0.12.2)
 
-## [v0.12.6](https://github.com/modbus2mqtt/angular/tree/v0.12.6) (2024-10-16)
+## [v0.12.0](https://github.com/volkmarnissen/angular/tree/v0.12.0) (2024-08-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.5...v0.12.6)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.11.0...v0.12.0)
 
-## [v0.12.5](https://github.com/modbus2mqtt/angular/tree/v0.12.5) (2024-09-24)
+## [v0.11.0](https://github.com/volkmarnissen/angular/tree/v0.11.0) (2024-08-05)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.4...v0.12.5)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.10.1...v0.11.0)
 
-## [v0.12.4](https://github.com/modbus2mqtt/angular/tree/v0.12.4) (2024-09-16)
+## [v0.10.1](https://github.com/volkmarnissen/angular/tree/v0.10.1) (2024-08-05)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.3...v0.12.4)
-
-## [v0.12.3](https://github.com/modbus2mqtt/angular/tree/v0.12.3) (2024-09-06)
-
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.2...v0.12.3)
-
-## [v0.12.2](https://github.com/modbus2mqtt/angular/tree/v0.12.2) (2024-08-27)
-
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.0...v0.12.2)
-
-## [v0.12.0](https://github.com/modbus2mqtt/angular/tree/v0.12.0) (2024-08-16)
-
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.11.0...v0.12.0)
-
-## [v0.11.0](https://github.com/modbus2mqtt/angular/tree/v0.11.0) (2024-08-05)
-
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.10.1...v0.11.0)
-
-## [v0.10.1](https://github.com/modbus2mqtt/angular/tree/v0.10.1) (2024-08-05)
-
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/0b2169b1bceece9fa4c2c6940ef33dafe96ae43b...v0.10.1)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/0b2169b1bceece9fa4c2c6940ef33dafe96ae43b...v0.10.1)
 
 
 

--- a/src/app/select-slave/select-slave.component.html
+++ b/src/app/select-slave/select-slave.component.html
@@ -47,8 +47,8 @@
 
                 <mat-select matInput formControlName="specificationid" (selectionChange)="onSpecificationChange(uislave)"
                   [compareWith]="compareSpecificationIdentification">
-                  <ng-container *ngIf="uislave.specsObservable|async  as identSpecs;else undetectedTemplate">
-                    <ng-container *ngFor="let i = index; let ispec of identSpecs">
+                  <ng-container *ngIf="uislave.specs;else undetectedTemplate">
+                    <ng-container *ngFor="let ispec of uislave.specs">
                     <mat-option [value]="ispec">
                       <mat-icon
                         [matTooltip]="statusTooltip(ispec?ispec.status:3)">{{statusIcon(ispec?ispec.status:3)}}</mat-icon>
@@ -59,7 +59,7 @@
                     </ng-container>
                   </ng-container>
                   <ng-template #undetectedTemplate >
-                    <ng-container *ngFor="let i = index; let ispec of preparedSpecs">
+                    <ng-container *ngFor="let ispec of preparedIdentSpecs">
                       <mat-option [value]="ispec">
                         <mat-icon
                           [matTooltip]="statusTooltip(ispec?ispec.status:3)">{{statusIcon(ispec?ispec.status:3)}}</mat-icon>

--- a/src/app/select-slave/select-slave.component.html
+++ b/src/app/select-slave/select-slave.component.html
@@ -47,8 +47,8 @@
 
                 <mat-select matInput formControlName="specificationid" (selectionChange)="onSpecificationChange(uislave)"
                   [compareWith]="compareSpecificationIdentification">
-                  <ng-container *ngIf="uislave.specs;else undetectedTemplate">
-                    <ng-container *ngFor="let ispec of uislave.specs">
+                  <ng-container *ngIf="uislave.specsObservable|async  as identSpecs;else undetectedTemplate">
+                    <ng-container *ngFor="let ispec of identSpecs">
                     <mat-option [value]="ispec">
                       <mat-icon
                         [matTooltip]="statusTooltip(ispec?ispec.status:3)">{{statusIcon(ispec?ispec.status:3)}}</mat-icon>

--- a/src/app/select-slave/select-slave.component.ts
+++ b/src/app/select-slave/select-slave.component.ts
@@ -80,7 +80,7 @@ import { isUndefined } from "cypress/types/lodash";
 interface IuiSlave {
   slave: Islave;
   label: string;
-  specsObservable?: Observable<IidentificationSpecification[]>;
+  specs?: IidentificationSpecification[];
   specification?: Ispecification;
   slaveForm: FormGroup;
   commandEntities?: ImodbusEntity[];
@@ -119,8 +119,7 @@ interface IuiSlave {
     MatExpansionPanelHeader,
     MatExpansionPanelTitle,
     MatInput,
-    MatError,
-    AsyncPipe,
+    MatError
   ],
 })
 export class SelectSlaveComponent extends SessionStorage implements OnInit {
@@ -177,19 +176,6 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
       this.currentLanguage = getCurrentLanguage(navigator.language);
       this.entityApiService.getSpecifications().subscribe((specs) => {
         this.preparedSpecs = specs;
-        specs.forEach((spec) => {
-          let name = getSpecificationI18nName(spec, this.currentLanguage);
-
-          let entities: IidentEntity[] = spec.entities.map((e) => {
-            return {
-              id: e.id,
-              name: e.name,
-              readonly: e.readonly,
-              mqttname: e.mqttname,
-            };
-          });
-          if (name == undefined) name = "unknown";
-        });
       });
       this.paramsSubscription = this.route.params.subscribe((params) => {
         let busId = +params["busid"];
@@ -197,6 +183,7 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
           this.bus = bus;
           if (this.bus) {
             this.busname = getConnectionName(this.bus.connectionData);
+            this.getIdentSpecs(undefined).then((identSpecs)=>{this.preparedIdentSpecs = identSpecs})
             this.updateSlaves();
           }
         });
@@ -345,8 +332,8 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
     );
     return rc
   }
-  getSpecsForConfiguredSlave(uiSlave:IuiSlave):Observable<IidentificationSpecification[]>{
-    let rc= new Subject<IidentificationSpecification[]>()
+  getIdentSpecs(uiSlave:IuiSlave| undefined ):Promise<IidentificationSpecification[]>{
+    return new Promise<IidentificationSpecification[]>((resolve, reject)=>{
     let fct = ( specModbus:ImodbusSpecification| undefined )=>{
       let rci:IidentificationSpecification[]=[]
       this.preparedSpecs.forEach(spec=>{
@@ -356,15 +343,14 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
             identified: specModbus && spec.filename== specModbus.filename?specModbus.identified:IdentifiedStates.unknown,
             filename: spec.filename,
           } as IidentificationSpecification);
-        rc.next(rci)       
       })
+      resolve(rci)
     }
-    if( uiSlave.slave.specificationid )
+    if( uiSlave && uiSlave.slave.specificationid )
       this.entityApiService.getModbusSpecification(this.bus.busId,uiSlave.slave.slaveid,uiSlave.slave.specificationid, true).subscribe(fct)
     else
       fct(undefined )
-
-    return rc;
+    })
   }
   getUiSlave(slave: Islave, detectSpec: boolean | undefined): IuiSlave {
     let fg = this.initiateSlaveControl(slave, null);
@@ -373,8 +359,7 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
       label: this.getSlaveName(slave),
       slaveForm: fg,
     } as any;
-    
-    rc.specsObservable = this.getSpecsForConfiguredSlave(rc) // getDetectedSpecs is disabled, because of performance issues
+    this.getIdentSpecs(rc).then((identSpecs)=>{rc.specs = identSpecs}).catch(e=>{ console.log(e.message)}) // getDetectedSpecs is disabled, because of performance issues
     this.addSpecificationToUiSlave(rc);
     (rc.selectedEntitites = this.getSelectedEntites(slave)),
       this.fillCommandTopics(rc);
@@ -592,10 +577,13 @@ export class SelectSlaveComponent extends SessionStorage implements OnInit {
           // Initialization of the UI
           // replacing this.uiSlaves with newUiSlaves will initialize and show it
           // Now, the new value needs to be marked as touched to enable cancel and save.
-          let specCtrl = newUiSlave.slaveForm.get("specificationid");
+          if( detectSpec){
+            let specCtrl = newUiSlave.slaveForm.get("specificationid");
 
-          if (specCtrl && specCtrl.value != undefined)
-            newUiSlave.slaveForm.markAllAsTouched();
+            if (specCtrl && specCtrl.value != undefined)
+              newUiSlave.slaveForm.markAllAsTouched();
+
+          }
         });
   }
   private static form2SlaveSetValue(uiSlave: IuiSlave, controlname: string) {

--- a/src/app/specification/entity/entity.component.ts
+++ b/src/app/specification/entity/entity.component.ts
@@ -439,7 +439,7 @@ export class EntityComponent
       this.entityFormGroup.get("readonly")!.setValue(entity.readonly);
     }
 
-    this.entityFormGroup.get("registerType")!.setValue(entity.registerType);
+    this.entityFormGroup.get("registerType")!.setValue( { registerType: entity.registerType, name: "unknown"});
     converterFormControl.setValue(entity.converter);
     modbusAddressFormControl.setValue(
       entity.modbusAddress != undefined ? entity.modbusAddress : null,


### PR DESCRIPTION
Fixed:
- Slave UI: Specification detection did not work.
- Error Handling: Too many restarts, to many error handling slowed detection down
- Slave UI: detect specifications for new Slaves only.
- Bus: Added support for TCP RTU bridge
- Slave UI: Load complete list of specifications before spec detection
- Modbus: Use same cache for a given busid even if the Bus was recreated
### Dependant Pullrequests
|Repository|Pull Request|
|----|----|
|[specification.shared](https://github.com/modbus2mqtt/specification.shared/pull/6)|6|
|[specification](https://github.com/modbus2mqtt/specification/pull/8)|8|
|[angular](https://github.com/modbus2mqtt/angular/pull/9)|9|
|[server](https://github.com/modbus2mqtt/server/pull/115)|115|
