### PR TITLE
[Feature] Add number of processed calls to Modbus Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,92 +1,120 @@
 # Changelog for angular
 
-## [v0.12.19](https://github.com/volkmarnissen/angular/tree/v0.12.19) (2025-01-16)
+## [Unreleased](https://github.com/modbus2mqtt/angular/tree/HEAD)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.18...v0.12.19)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.20...HEAD)
 
-## [v0.12.18](https://github.com/volkmarnissen/angular/tree/v0.12.18) (2025-01-15)
+**Merged pull requests:**
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.17...v0.12.18)
+- \[Feature\] Add number of processed calls to Modbus Status [\#11](https://github.com/modbus2mqtt/angular/pull/11) ([volkmarnissen](https://github.com/volkmarnissen))
+- Update Changelog [\#10](https://github.com/modbus2mqtt/angular/pull/10) ([volkmarnissen](https://github.com/volkmarnissen))
+- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#9](https://github.com/modbus2mqtt/angular/pull/9) ([volkmarnissen](https://github.com/volkmarnissen))
+- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#8](https://github.com/modbus2mqtt/angular/pull/8) ([volkmarnissen](https://github.com/volkmarnissen))
+- Angular TcpBridge Fix [\#7](https://github.com/modbus2mqtt/angular/pull/7) ([volkmarnissen](https://github.com/volkmarnissen))
+- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#6](https://github.com/modbus2mqtt/angular/pull/6) ([volkmarnissen](https://github.com/volkmarnissen))
+- Modbus Error Handling and Monitoring [\#5](https://github.com/modbus2mqtt/angular/pull/5) ([volkmarnissen](https://github.com/volkmarnissen))
 
-## [v0.12.17](https://github.com/volkmarnissen/angular/tree/v0.12.17) (2025-01-02)
+## [v0.12.20](https://github.com/modbus2mqtt/angular/tree/v0.12.20) (2025-04-14)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.16...v0.12.17)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.19...v0.12.20)
 
-## [v0.12.16](https://github.com/volkmarnissen/angular/tree/v0.12.16) (2024-12-31)
+**Merged pull requests:**
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.15...v0.12.16)
+- Please update me [\#4](https://github.com/modbus2mqtt/angular/pull/4) ([volkmarnissen](https://github.com/volkmarnissen))
+- Fixed package-lock.json [\#3](https://github.com/modbus2mqtt/angular/pull/3) ([volkmarnissen](https://github.com/volkmarnissen))
+- Adding support for discrete inputs [\#2](https://github.com/modbus2mqtt/angular/pull/2) ([arturmietek](https://github.com/arturmietek))
 
-## [v0.12.15](https://github.com/volkmarnissen/angular/tree/v0.12.15) (2024-12-30)
+## [v0.12.19](https://github.com/modbus2mqtt/angular/tree/v0.12.19) (2025-01-16)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.14...v0.12.15)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.18...v0.12.19)
 
-## [v0.12.14](https://github.com/volkmarnissen/angular/tree/v0.12.14) (2024-12-30)
+## [v0.12.18](https://github.com/modbus2mqtt/angular/tree/v0.12.18) (2025-01-15)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/0.12.14...v0.12.14)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.17...v0.12.18)
 
-## [0.12.14](https://github.com/volkmarnissen/angular/tree/0.12.14) (2024-12-13)
+## [v0.12.17](https://github.com/modbus2mqtt/angular/tree/v0.12.17) (2025-01-02)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.13...0.12.14)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.16...v0.12.17)
 
-## [v0.12.13](https://github.com/volkmarnissen/angular/tree/v0.12.13) (2024-12-13)
+**Merged pull requests:**
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.12...v0.12.13)
+- Adding signed int 32 and unsigned int 32 options to number format [\#1](https://github.com/modbus2mqtt/angular/pull/1) ([arturmietek](https://github.com/arturmietek))
 
-## [v0.12.12](https://github.com/volkmarnissen/angular/tree/v0.12.12) (2024-12-11)
+## [v0.12.16](https://github.com/modbus2mqtt/angular/tree/v0.12.16) (2024-12-31)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.11...v0.12.12)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.15...v0.12.16)
 
-## [v0.12.11](https://github.com/volkmarnissen/angular/tree/v0.12.11) (2024-11-22)
+## [v0.12.15](https://github.com/modbus2mqtt/angular/tree/v0.12.15) (2024-12-30)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.10...v0.12.11)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.14...v0.12.15)
 
-## [v0.12.10](https://github.com/volkmarnissen/angular/tree/v0.12.10) (2024-11-19)
+## [v0.12.14](https://github.com/modbus2mqtt/angular/tree/v0.12.14) (2024-12-30)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.9...v0.12.10)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/0.12.14...v0.12.14)
 
-## [v0.12.9](https://github.com/volkmarnissen/angular/tree/v0.12.9) (2024-11-16)
+## [0.12.14](https://github.com/modbus2mqtt/angular/tree/0.12.14) (2024-12-13)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.8...v0.12.9)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.13...0.12.14)
 
-## [v0.12.8](https://github.com/volkmarnissen/angular/tree/v0.12.8) (2024-11-14)
+## [v0.12.13](https://github.com/modbus2mqtt/angular/tree/v0.12.13) (2024-12-13)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.7...v0.12.8)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.12...v0.12.13)
 
-## [v0.12.7](https://github.com/volkmarnissen/angular/tree/v0.12.7) (2024-10-23)
+## [v0.12.12](https://github.com/modbus2mqtt/angular/tree/v0.12.12) (2024-12-11)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.6...v0.12.7)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.11...v0.12.12)
 
-## [v0.12.6](https://github.com/volkmarnissen/angular/tree/v0.12.6) (2024-10-16)
+## [v0.12.11](https://github.com/modbus2mqtt/angular/tree/v0.12.11) (2024-11-22)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.5...v0.12.6)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.10...v0.12.11)
 
-## [v0.12.5](https://github.com/volkmarnissen/angular/tree/v0.12.5) (2024-09-24)
+## [v0.12.10](https://github.com/modbus2mqtt/angular/tree/v0.12.10) (2024-11-19)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.4...v0.12.5)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.9...v0.12.10)
 
-## [v0.12.4](https://github.com/volkmarnissen/angular/tree/v0.12.4) (2024-09-16)
+## [v0.12.9](https://github.com/modbus2mqtt/angular/tree/v0.12.9) (2024-11-16)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.3...v0.12.4)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.8...v0.12.9)
 
-## [v0.12.3](https://github.com/volkmarnissen/angular/tree/v0.12.3) (2024-09-06)
+## [v0.12.8](https://github.com/modbus2mqtt/angular/tree/v0.12.8) (2024-11-14)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.2...v0.12.3)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.7...v0.12.8)
 
-## [v0.12.2](https://github.com/volkmarnissen/angular/tree/v0.12.2) (2024-08-27)
+## [v0.12.7](https://github.com/modbus2mqtt/angular/tree/v0.12.7) (2024-10-23)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.0...v0.12.2)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.6...v0.12.7)
 
-## [v0.12.0](https://github.com/volkmarnissen/angular/tree/v0.12.0) (2024-08-16)
+## [v0.12.6](https://github.com/modbus2mqtt/angular/tree/v0.12.6) (2024-10-16)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.11.0...v0.12.0)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.5...v0.12.6)
 
-## [v0.11.0](https://github.com/volkmarnissen/angular/tree/v0.11.0) (2024-08-05)
+## [v0.12.5](https://github.com/modbus2mqtt/angular/tree/v0.12.5) (2024-09-24)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.10.1...v0.11.0)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.4...v0.12.5)
 
-## [v0.10.1](https://github.com/volkmarnissen/angular/tree/v0.10.1) (2024-08-05)
+## [v0.12.4](https://github.com/modbus2mqtt/angular/tree/v0.12.4) (2024-09-16)
 
-[Full Changelog](https://github.com/volkmarnissen/angular/compare/0b2169b1bceece9fa4c2c6940ef33dafe96ae43b...v0.10.1)
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.3...v0.12.4)
+
+## [v0.12.3](https://github.com/modbus2mqtt/angular/tree/v0.12.3) (2024-09-06)
+
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.2...v0.12.3)
+
+## [v0.12.2](https://github.com/modbus2mqtt/angular/tree/v0.12.2) (2024-08-27)
+
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.0...v0.12.2)
+
+## [v0.12.0](https://github.com/modbus2mqtt/angular/tree/v0.12.0) (2024-08-16)
+
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.11.0...v0.12.0)
+
+## [v0.11.0](https://github.com/modbus2mqtt/angular/tree/v0.11.0) (2024-08-05)
+
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.10.1...v0.11.0)
+
+## [v0.10.1](https://github.com/modbus2mqtt/angular/tree/v0.10.1) (2024-08-05)
+
+[Full Changelog](https://github.com/modbus2mqtt/angular/compare/0b2169b1bceece9fa4c2c6940ef33dafe96ae43b...v0.10.1)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,120 +1,92 @@
 # Changelog for angular
 
-## [Unreleased](https://github.com/modbus2mqtt/angular/tree/HEAD)
+## [v0.12.19](https://github.com/volkmarnissen/angular/tree/v0.12.19) (2025-01-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.20...HEAD)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.18...v0.12.19)
 
-**Merged pull requests:**
+## [v0.12.18](https://github.com/volkmarnissen/angular/tree/v0.12.18) (2025-01-15)
 
-- \[Feature\] Add number of processed calls to Modbus Status [\#11](https://github.com/modbus2mqtt/angular/pull/11) ([volkmarnissen](https://github.com/volkmarnissen))
-- Update Changelog [\#10](https://github.com/modbus2mqtt/angular/pull/10) ([volkmarnissen](https://github.com/volkmarnissen))
-- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#9](https://github.com/modbus2mqtt/angular/pull/9) ([volkmarnissen](https://github.com/volkmarnissen))
-- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#8](https://github.com/modbus2mqtt/angular/pull/8) ([volkmarnissen](https://github.com/volkmarnissen))
-- Angular TcpBridge Fix [\#7](https://github.com/modbus2mqtt/angular/pull/7) ([volkmarnissen](https://github.com/volkmarnissen))
-- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#6](https://github.com/modbus2mqtt/angular/pull/6) ([volkmarnissen](https://github.com/volkmarnissen))
-- Modbus Error Handling and Monitoring [\#5](https://github.com/modbus2mqtt/angular/pull/5) ([volkmarnissen](https://github.com/volkmarnissen))
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.17...v0.12.18)
 
-## [v0.12.20](https://github.com/modbus2mqtt/angular/tree/v0.12.20) (2025-04-14)
+## [v0.12.17](https://github.com/volkmarnissen/angular/tree/v0.12.17) (2025-01-02)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.19...v0.12.20)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.16...v0.12.17)
 
-**Merged pull requests:**
+## [v0.12.16](https://github.com/volkmarnissen/angular/tree/v0.12.16) (2024-12-31)
 
-- Please update me [\#4](https://github.com/modbus2mqtt/angular/pull/4) ([volkmarnissen](https://github.com/volkmarnissen))
-- Fixed package-lock.json [\#3](https://github.com/modbus2mqtt/angular/pull/3) ([volkmarnissen](https://github.com/volkmarnissen))
-- Adding support for discrete inputs [\#2](https://github.com/modbus2mqtt/angular/pull/2) ([arturmietek](https://github.com/arturmietek))
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.15...v0.12.16)
 
-## [v0.12.19](https://github.com/modbus2mqtt/angular/tree/v0.12.19) (2025-01-16)
+## [v0.12.15](https://github.com/volkmarnissen/angular/tree/v0.12.15) (2024-12-30)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.18...v0.12.19)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.14...v0.12.15)
 
-## [v0.12.18](https://github.com/modbus2mqtt/angular/tree/v0.12.18) (2025-01-15)
+## [v0.12.14](https://github.com/volkmarnissen/angular/tree/v0.12.14) (2024-12-30)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.17...v0.12.18)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/0.12.14...v0.12.14)
 
-## [v0.12.17](https://github.com/modbus2mqtt/angular/tree/v0.12.17) (2025-01-02)
+## [0.12.14](https://github.com/volkmarnissen/angular/tree/0.12.14) (2024-12-13)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.16...v0.12.17)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.13...0.12.14)
 
-**Merged pull requests:**
+## [v0.12.13](https://github.com/volkmarnissen/angular/tree/v0.12.13) (2024-12-13)
 
-- Adding signed int 32 and unsigned int 32 options to number format [\#1](https://github.com/modbus2mqtt/angular/pull/1) ([arturmietek](https://github.com/arturmietek))
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.12...v0.12.13)
 
-## [v0.12.16](https://github.com/modbus2mqtt/angular/tree/v0.12.16) (2024-12-31)
+## [v0.12.12](https://github.com/volkmarnissen/angular/tree/v0.12.12) (2024-12-11)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.15...v0.12.16)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.11...v0.12.12)
 
-## [v0.12.15](https://github.com/modbus2mqtt/angular/tree/v0.12.15) (2024-12-30)
+## [v0.12.11](https://github.com/volkmarnissen/angular/tree/v0.12.11) (2024-11-22)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.14...v0.12.15)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.10...v0.12.11)
 
-## [v0.12.14](https://github.com/modbus2mqtt/angular/tree/v0.12.14) (2024-12-30)
+## [v0.12.10](https://github.com/volkmarnissen/angular/tree/v0.12.10) (2024-11-19)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/0.12.14...v0.12.14)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.9...v0.12.10)
 
-## [0.12.14](https://github.com/modbus2mqtt/angular/tree/0.12.14) (2024-12-13)
+## [v0.12.9](https://github.com/volkmarnissen/angular/tree/v0.12.9) (2024-11-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.13...0.12.14)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.8...v0.12.9)
 
-## [v0.12.13](https://github.com/modbus2mqtt/angular/tree/v0.12.13) (2024-12-13)
+## [v0.12.8](https://github.com/volkmarnissen/angular/tree/v0.12.8) (2024-11-14)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.12...v0.12.13)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.7...v0.12.8)
 
-## [v0.12.12](https://github.com/modbus2mqtt/angular/tree/v0.12.12) (2024-12-11)
+## [v0.12.7](https://github.com/volkmarnissen/angular/tree/v0.12.7) (2024-10-23)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.11...v0.12.12)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.6...v0.12.7)
 
-## [v0.12.11](https://github.com/modbus2mqtt/angular/tree/v0.12.11) (2024-11-22)
+## [v0.12.6](https://github.com/volkmarnissen/angular/tree/v0.12.6) (2024-10-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.10...v0.12.11)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.5...v0.12.6)
 
-## [v0.12.10](https://github.com/modbus2mqtt/angular/tree/v0.12.10) (2024-11-19)
+## [v0.12.5](https://github.com/volkmarnissen/angular/tree/v0.12.5) (2024-09-24)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.9...v0.12.10)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.4...v0.12.5)
 
-## [v0.12.9](https://github.com/modbus2mqtt/angular/tree/v0.12.9) (2024-11-16)
+## [v0.12.4](https://github.com/volkmarnissen/angular/tree/v0.12.4) (2024-09-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.8...v0.12.9)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.3...v0.12.4)
 
-## [v0.12.8](https://github.com/modbus2mqtt/angular/tree/v0.12.8) (2024-11-14)
+## [v0.12.3](https://github.com/volkmarnissen/angular/tree/v0.12.3) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.7...v0.12.8)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.2...v0.12.3)
 
-## [v0.12.7](https://github.com/modbus2mqtt/angular/tree/v0.12.7) (2024-10-23)
+## [v0.12.2](https://github.com/volkmarnissen/angular/tree/v0.12.2) (2024-08-27)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.6...v0.12.7)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.12.0...v0.12.2)
 
-## [v0.12.6](https://github.com/modbus2mqtt/angular/tree/v0.12.6) (2024-10-16)
+## [v0.12.0](https://github.com/volkmarnissen/angular/tree/v0.12.0) (2024-08-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.5...v0.12.6)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.11.0...v0.12.0)
 
-## [v0.12.5](https://github.com/modbus2mqtt/angular/tree/v0.12.5) (2024-09-24)
+## [v0.11.0](https://github.com/volkmarnissen/angular/tree/v0.11.0) (2024-08-05)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.4...v0.12.5)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/v0.10.1...v0.11.0)
 
-## [v0.12.4](https://github.com/modbus2mqtt/angular/tree/v0.12.4) (2024-09-16)
+## [v0.10.1](https://github.com/volkmarnissen/angular/tree/v0.10.1) (2024-08-05)
 
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.3...v0.12.4)
-
-## [v0.12.3](https://github.com/modbus2mqtt/angular/tree/v0.12.3) (2024-09-06)
-
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.2...v0.12.3)
-
-## [v0.12.2](https://github.com/modbus2mqtt/angular/tree/v0.12.2) (2024-08-27)
-
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.12.0...v0.12.2)
-
-## [v0.12.0](https://github.com/modbus2mqtt/angular/tree/v0.12.0) (2024-08-16)
-
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.11.0...v0.12.0)
-
-## [v0.11.0](https://github.com/modbus2mqtt/angular/tree/v0.11.0) (2024-08-05)
-
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/v0.10.1...v0.11.0)
-
-## [v0.10.1](https://github.com/modbus2mqtt/angular/tree/v0.10.1) (2024-08-05)
-
-[Full Changelog](https://github.com/modbus2mqtt/angular/compare/0b2169b1bceece9fa4c2c6940ef33dafe96ae43b...v0.10.1)
+[Full Changelog](https://github.com/volkmarnissen/angular/compare/0b2169b1bceece9fa4c2c6940ef33dafe96ae43b...v0.10.1)
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4081,7 +4081,7 @@
     },
     "node_modules/@modbus2mqtt/specification.shared": {
       "version": "0.10.11",
-      "resolved": "git+ssh://git@github.com/modbus2mqtt/specification.shared.git#605903cbd0a618abaf5817b3052b02e47c8ad491",
+      "resolved": "git+ssh://git@github.com/modbus2mqtt/specification.shared.git#482ce60f03c8e0ea5c8e12b1c76a1bb1d12a9528",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4081,7 +4081,7 @@
     },
     "node_modules/@modbus2mqtt/specification.shared": {
       "version": "0.10.11",
-      "resolved": "git+ssh://git@github.com/modbus2mqtt/specification.shared.git#482ce60f03c8e0ea5c8e12b1c76a1bb1d12a9528",
+      "resolved": "git+ssh://git@github.com/modbus2mqtt/specification.shared.git#605903cbd0a618abaf5817b3052b02e47c8ad491",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
Add number of processed calls to Modbus Status

### Dependant Pullrequests
|Repository|Pull Request|
|----|----|
|[specification](https://github.com/modbus2mqtt/specification/pull/11)|11|
|[server.shared](https://github.com/modbus2mqtt/server.shared/pull/6)|6|
|[angular](https://github.com/modbus2mqtt/angular/pull/12)|12|
|[server](https://github.com/modbus2mqtt/server/pull/119)|119|
